### PR TITLE
Create a wrapper for request animation frame

### DIFF
--- a/src/components/cm-button/cm-button.tsx
+++ b/src/components/cm-button/cm-button.tsx
@@ -12,7 +12,11 @@ import {
 	Method,
 	Watch,
 } from '@stencil/core'
-import { onThemeChange, Theme } from '../../globalHelpers'
+import {
+	onThemeChange,
+	Theme,
+	ensureRequestAnimationFrame,
+} from '../../globalHelpers'
 
 @Component({
 	tag: 'cm-button',
@@ -46,7 +50,7 @@ export class CmButton implements ComponentInterface {
 		div.classList.add('appearanceChange')
 		span.classList.add('appearanceChange')
 
-		requestAnimationFrame(() => {
+		ensureRequestAnimationFrame(() => {
 			div.classList.remove('appearanceChange')
 			span.classList.remove('appearanceChange')
 		})

--- a/src/components/cm-checkbox/cm-checkbox.tsx
+++ b/src/components/cm-checkbox/cm-checkbox.tsx
@@ -12,7 +12,12 @@ import {
 	Element,
 } from '@stencil/core'
 
-import { onThemeChange, Theme, ValidatorResult } from '../../globalHelpers'
+import {
+	onThemeChange,
+	Theme,
+	ValidatorResult,
+	ensureRequestAnimationFrame,
+} from '../../globalHelpers'
 import { CmIcon } from '../cm-icon/cm-icon'
 
 @Component({
@@ -52,7 +57,7 @@ export class CmCheckbox {
 			if (checkbox !== undefined) {
 				checkbox.classList.add('appearanceChange')
 
-				requestAnimationFrame(() => {
+				ensureRequestAnimationFrame(() => {
 					checkbox.classList.remove('appearanceChange')
 				})
 			}

--- a/src/components/cm-radiobutton/cm-radiobutton.tsx
+++ b/src/components/cm-radiobutton/cm-radiobutton.tsx
@@ -10,7 +10,7 @@ import {
 	Element,
 	State,
 } from '@stencil/core'
-import { onThemeChange, Theme } from '../../globalHelpers'
+import { onThemeChange, Theme, reqAnimationFrame } from '../../globalHelpers'
 
 @Component({
 	tag: 'cm-radiobutton',
@@ -37,7 +37,7 @@ export class CmRadiobutton {
 			if (div !== null) {
 				div.classList.add('appearanceChange')
 
-				requestAnimationFrame(() => {
+				reqAnimationFrame(() => {
 					div.classList.remove('appearanceChange')
 				})
 			}

--- a/src/components/cm-textfield/cm-textfield.tsx
+++ b/src/components/cm-textfield/cm-textfield.tsx
@@ -14,6 +14,7 @@ import {
 	onThemeChange,
 	Theme,
 	ValidatorResult,
+	ensureRequestAnimationFrame,
 } from '../../globalHelpers'
 import { CmIcon } from '../cm-icon/cm-icon'
 
@@ -129,7 +130,7 @@ export class CmTextfield {
 			if (div !== null) {
 				div.classList.add('appearanceChange')
 
-				requestAnimationFrame(() => {
+				ensureRequestAnimationFrame(() => {
 					div.classList.remove('appearanceChange')
 				})
 			}

--- a/src/globalHelpers.ts
+++ b/src/globalHelpers.ts
@@ -82,3 +82,10 @@ export const debounce = (callback: Function, wait: number) => {
 		timeout = setTimeout(later, wait)
 	}
 }
+
+// Workaround for: https://bugs.chromium.org/p/chromium/issues/detail?id=675795
+export const ensureRequestAnimationFrame = (callback: FrameRequestCallback) => {
+	requestAnimationFrame(() => {
+		requestAnimationFrame(callback)
+	})
+}


### PR DESCRIPTION
Because of an issue described here;

<img width="773" alt="Screenshot 2022-01-25 at 12 40 50" src="https://user-images.githubusercontent.com/45518829/150951791-7a3761d8-4946-4f8e-866d-8cc704746153.png">
(https://sebastiandedeyne.com/javascript-framework-diet/enter-leave-transitions/)

we are using a workaround for removing 'appearanceChange' class from the components on theme change. 