### PR TITLE
Fix cm-checkbox warning message style

### DIFF
--- a/src/components/cm-checkbox/cm-checkbox.scss
+++ b/src/components/cm-checkbox/cm-checkbox.scss
@@ -217,7 +217,7 @@
 	}
 }
 
-cm-icon {
+.icon {
 	grid-area: icon;
 	margin-left: 6px;
 }
@@ -259,8 +259,6 @@ cm-text {
 	font-family: var(--cm-font-text);
 	font-size: 13px;
 	color: var(--cm-color-red-base);
-
-	padding-left: 2px;
 
 	&:not(:empty) {
 		padding-top: 8px;

--- a/src/components/cm-checkbox/cm-checkbox.tsx
+++ b/src/components/cm-checkbox/cm-checkbox.tsx
@@ -294,6 +294,7 @@ export class CmCheckbox {
 					></div>
 					{this.icon ? (
 						<cm-icon
+							class="icon"
 							icon={this.icon.icon}
 							color={this.icon.color}
 							ignoreTheme={this.icon.ignoreTheme}


### PR DESCRIPTION
Fixes the following:

- The alignment of the error warning icon. This was happening because styles for cm-icon was overridden when implementing [icon support for cm-checkbox](https://github.com/camunda-cloud/common-ui/commit/b2c9c52cfdc772f7e338c5845440010e8a5297fe#diff-3702eba8d127d683c7ef86dad146795b604395f0f1415a50264b5a00315888caR153) . since cm-icon is also used for warning icon, changed this checkbox-icon to use a class instead.

<img width="396" alt="Screenshot 2023-02-17 at 13 51 28" src="https://user-images.githubusercontent.com/45518829/219626244-74306b66-e15d-4458-ab45-4e84af9bfb2b.png">

- remove padding 2px on the left side of the warning icon, because there doesn't seem to be any spacing in the new requirements

